### PR TITLE
[JAX SC] Add Pyrefly lint checking to CI build and test workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,34 @@
+name: Lint
+
+on:
+  push:
+    branches:
+    - main
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  pyrefly:
+    runs-on: linux-x86-n4-16
+    container: us-docker.pkg.dev/ml-oss-artifacts-published/ml-public-container/ml-build:latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Display Python version
+        run: python -c "import sys; print(sys.version)"
+
+      - name: Install lint and project dependencies
+        run: |
+          python -m pip install --upgrade --root-user-action=ignore pip setuptools wheel pyrefly
+          python -m pip install --root-user-action=ignore -r third_party/py/requirements_lock_3_12.txt
+
+      - name: Run Pyrefly check
+        run: pyrefly check

--- a/jax_tpu_embedding/sparsecore/lib/core/primitives/sparse_dense_matmul_optimizer_grad.py
+++ b/jax_tpu_embedding/sparsecore/lib/core/primitives/sparse_dense_matmul_optimizer_grad.py
@@ -224,7 +224,7 @@ def _tpu_sparse_dense_matmul_optimizer_grad_lowering(
         *in_args,
         dim_var_values=[],
         const_lowering={},
-        outer_traceback=None,
+        outer_traceback=None,  # pyrefly: ignore[unexpected-keyword]
     )
 
     flat_out_vals = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,3 +42,23 @@ include = ["jax_tpu_embedding*"]
 
 [tool.setuptools.package-data]
 "*" = ["*.dylib", "*.so", "*.pyd"]
+
+[tool.pyrefly]
+preset = "basic"
+python-version = "3.12"
+project-includes = [
+    "jax_tpu_embedding/**/*.py*",
+    "jax_tpu_embedding/**/*.ipynb",
+]
+ignore-missing-imports = [
+    "absl.*",
+    "einops.*",
+    "flax.*",
+    "google_benchmark.*",
+    "jax.*",
+    "jaxlib.*",
+    "numpy.*",
+    "portpicker.*",
+    "setuptools.*",
+]
+untyped-def-behavior = "check-and-infer-return-any"


### PR DESCRIPTION
Configure Pyrefly in pyproject.toml targeting Python 3.12 (with basic preset and third-party import ignores) and add a Pyrefly lint check step to .github/workflows/build_and_test.yml.