### PR TITLE
[JAX SC] Modernize CI: uv, C++ linter, and OSS TPU tests (Test PR)

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,12 @@
+# GitHub Actions Workflows
+
+See the GitHub documentation for more information on GitHub Actions in general.
+
+## Notes & Security Best Practices
+
+* **Action SHA Pinning**: <https://opensource.google/documentation/reference/github/services#actions> mandates using a specific commit SHA for non-Google actions. We use [Ratchet](https://github.com/sethvargo/ratchet) to pin specific versions. If you'd like to update or add an action, you can write something like `uses: 'actions/checkout@v4'`, and then run `ratchet pin .github/workflows/*.yml` to convert mutable tags to immutable commit hashes with version comments.
+* **Fork PR Protection**: Self-hosted Cloud TPU VM runners (`linux-x86-ct5lp-224-8tpu`, `linux-x86-ct6e-180-8tpu`) execute on Google-internal VPC infrastructure. To prevent untrusted code execution from arbitrary forks, all TPU workflows MUST include the security guard:
+  ```yaml
+  if: github.event.repository.fork == false && github.repository_owner == 'jax-ml'
+  ```
+  Fork PRs do not execute TPU tests automatically. When testing an external contributor's PR on TPU, a repository maintainer must pull the branch internally or trigger a manual test run.

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -9,19 +9,32 @@ on:
   pull_request:
   workflow_dispatch:
 
-permissions:
-  contents: read      # Lets the job check out your code
-  actions: write      # Lets the job write (save) the cache
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+env:
+  UV_DEFAULT_INDEX: "https://us-python.pkg.dev/ml-oss-artifacts-published/pypi-mirror/simple"
+  PIP_INDEX_URL: "https://us-python.pkg.dev/ml-oss-artifacts-published/pypi-mirror/simple"
 
 jobs:
   build-and-test-cpu:
     runs-on: linux-x86-n4-16
     container: us-docker.pkg.dev/ml-oss-artifacts-published/ml-public-container/ml-build:latest
+    timeout-minutes: 60
+    permissions:
+      contents: read      # Lets the job check out your code
+      actions: write      # Lets the job write (save) the cache
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
 
-      - name: Set up Python 3.12
-        uses: actions/setup-python@v5
+      - name: Set up Python 3.12 via uv
+        id: setup_python
+        uses: google-ml-infra/actions/setup-uv-python@a1817800cb84c752378772c2a02781cf8309a399
         with:
           python-version: '3.12'
 
@@ -29,15 +42,17 @@ jobs:
         run: python -c "import sys; print(sys.version)"
 
       - name: Install dependencies
+        env:
+          PYTHON_BIN: ${{ steps.setup_python.outputs.python-bin }}
         run: |
-          python -m pip install --upgrade --root-user-action=ignore pip setuptools wheel
+          uv pip install --python "$PYTHON_BIN" --upgrade pip setuptools wheel
           bash tools/install_bazelisk.sh
 
       # --- FOR PULL REQUESTS ---
       # Restore the cache from the main branch's base commit.
       - if: github.event_name == 'pull_request'
         name: Mount bazel cache (pull-request)
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         with:
           path: "/__w/.cache/bazel"
           key: bazel-py3.12-${{ github.base_ref }}-${{ github.event.pull_request.base.sha }}
@@ -50,7 +65,7 @@ jobs:
       # Restore the cache from the previous commit.
       - if: github.event_name != 'pull_request'
         name: Mount bazel cache (main)
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         with:
           path: "/__w/.cache/bazel"
           # Try to find the cache from the exact commit *before* this push
@@ -84,7 +99,7 @@ jobs:
       # --- SAVE NEW CACHE ---
       - name: Save bazel cache (main)
         if: github.event_name != 'pull_request'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
         with:
           path: "/__w/.cache/bazel"
           key: bazel-py3.12-${{ github.ref_name }}-${{ github.sha }}

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -18,6 +18,7 @@ concurrency:
 env:
   UV_DEFAULT_INDEX: "https://us-python.pkg.dev/ml-oss-artifacts-published/pypi-mirror/simple"
   PIP_INDEX_URL: "https://us-python.pkg.dev/ml-oss-artifacts-published/pypi-mirror/simple"
+  UV_INDEX_STRATEGY: "unsafe-best-match"
 
 jobs:
   build-and-test-cpu:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,10 +16,12 @@ concurrency:
 env:
   UV_DEFAULT_INDEX: "https://us-python.pkg.dev/ml-oss-artifacts-published/pypi-mirror/simple"
   PIP_INDEX_URL: "https://us-python.pkg.dev/ml-oss-artifacts-published/pypi-mirror/simple"
+  UV_INDEX_STRATEGY: "unsafe-best-match"
 
 jobs:
   pyrefly:
-    runs-on: ubuntu-latest
+    runs-on: linux-x86-n4-16
+    container: us-docker.pkg.dev/ml-oss-artifacts-published/ml-public-container/ml-build:latest
     timeout-minutes: 15
     permissions:
       contents: read

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,18 +7,30 @@ on:
   pull_request:
   workflow_dispatch:
 
-permissions:
-  contents: read
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+env:
+  UV_DEFAULT_INDEX: "https://us-python.pkg.dev/ml-oss-artifacts-published/pypi-mirror/simple"
+  PIP_INDEX_URL: "https://us-python.pkg.dev/ml-oss-artifacts-published/pypi-mirror/simple"
 
 jobs:
   pyrefly:
-    runs-on: linux-x86-n4-16
-    container: us-docker.pkg.dev/ml-oss-artifacts-published/ml-public-container/ml-build:latest
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          persist-credentials: false
 
-      - name: Set up Python 3.12
-        uses: actions/setup-python@v5
+      - name: Set up Python 3.12 via uv
+        id: setup_python
+        uses: google-ml-infra/actions/setup-uv-python@a1817800cb84c752378772c2a02781cf8309a399
         with:
           python-version: '3.12'
 
@@ -26,9 +38,17 @@ jobs:
         run: python -c "import sys; print(sys.version)"
 
       - name: Install lint and project dependencies
+        env:
+          PYTHON_BIN: ${{ steps.setup_python.outputs.python-bin }}
         run: |
-          python -m pip install --upgrade --root-user-action=ignore pip setuptools wheel pyrefly
-          python -m pip install --root-user-action=ignore -r third_party/py/requirements_lock_3_12.txt
+          uv pip install --python "$PYTHON_BIN" --upgrade pip setuptools wheel pyrefly clang-format
+          uv pip install --python "$PYTHON_BIN" -r third_party/py/requirements_lock_3_12.txt
 
       - name: Run Pyrefly check
-        run: pyrefly check
+        env:
+          PYTHON_BIN: ${{ steps.setup_python.outputs.python-bin }}
+        run: "$PYTHON_BIN" -m pyrefly check
+
+      - name: Run C++ clang-format check on core headers and sources
+        run: |
+          find jax_tpu_embedding/sparsecore/lib/core -name '*.cc' -o -name '*.h' | xargs clang-format --dry-run -Werror

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -49,7 +49,8 @@ jobs:
       - name: Run Pyrefly check
         env:
           PYTHON_BIN: ${{ steps.setup_python.outputs.python-bin }}
-        run: "$PYTHON_BIN" -m pyrefly check
+        run: |
+          "$PYTHON_BIN" -m pyrefly check
 
       - name: Run C++ clang-format check on core headers and sources
         run: |

--- a/.github/workflows/tpu_test.yml
+++ b/.github/workflows/tpu_test.yml
@@ -112,8 +112,37 @@ jobs:
         if: steps.check.outputs.skip == 'false'
         run: |
           export HERMETIC_PYTHON_VERSION=3.12
-          # Filter specifically for requires-tpu tagged tests; execute sequentially (--local_test_jobs=1) to prevent TPU device lock contention
-          bazel test --config=public_cache --build_tests_only --test_tag_filters=requires-tpu --local_test_jobs=1 --test_output=errors --keep_going //...
+          # Forward TPU cluster environment variables from runner host into Bazel test execution
+          bazel test --config=public_cache --build_tests_only \
+            --test_tag_filters=requires-tpu --local_test_jobs=1 \
+            --test_env=JAX_PLATFORMS=tpu,cpu \
+            --test_env=ALLOW_MULTIPLE_LIBTPU_LOAD=true \
+            --test_env=TPU_SKIP_MDS_QUERY=true \
+            --test_env=TPU_TOPOLOGY \
+            --test_env=TPU_WORKER_ID \
+            --test_env=TPU_TOPOLOGY_WRAP \
+            --test_env=TPU_CHIPS_PER_HOST_BOUNDS \
+            --test_env=TPU_ACCELERATOR_TYPE \
+            --test_env=TPU_RUNTIME_METRICS_PORTS \
+            --test_env=TPU_TOPOLOGY_ALT \
+            --test_env=TPU_HOST_BOUNDS \
+            --test_env=TPU_WORKER_HOSTNAMES \
+            --test_env=CHIPS_PER_HOST_BOUNDS \
+            --test_env=HOST_BOUNDS \
+            --test_env=VBAR_CONTROL_SERVICE_URL \
+            --test_output=errors --keep_going //...
+
+      - name: Build and verify wheel on TPU via Pytest
+        if: steps.check.outputs.skip == 'false'
+        env:
+          PYTHON_BIN: ${{ steps.setup_python.outputs.python-bin }}
+        run: |
+          export HERMETIC_PYTHON_VERSION=3.12
+          bazel run --config=public_cache //tools:build_wheel
+          uv pip install --python "$PYTHON_BIN" dist/*.whl pytest
+          # Run pytest across TPU tests from outside the workspace root to test installed wheel
+          mkdir -p /tmp/tpu_wheel_test && cd /tmp/tpu_wheel_test
+          JAX_PLATFORMS=tpu,cpu ALLOW_MULTIPLE_LIBTPU_LOAD=true TPU_SKIP_MDS_QUERY=true "$PYTHON_BIN" -m pytest --tb=short "$GITHUB_WORKSPACE/tests" "$GITHUB_WORKSPACE/sparsecore" -k "tpu or sparsecore or embedding"
 
       - name: Save Bazel cache
         if: steps.check.outputs.skip == 'false' && github.event_name != 'pull_request'

--- a/.github/workflows/tpu_test.yml
+++ b/.github/workflows/tpu_test.yml
@@ -30,6 +30,7 @@ concurrency:
 env:
   UV_DEFAULT_INDEX: "https://us-python.pkg.dev/ml-oss-artifacts-published/pypi-mirror/simple"
   PIP_INDEX_URL: "https://us-python.pkg.dev/ml-oss-artifacts-published/pypi-mirror/simple"
+  UV_INDEX_STRATEGY: "unsafe-best-match"
 
 jobs:
   tpu-test:

--- a/.github/workflows/tpu_test.yml
+++ b/.github/workflows/tpu_test.yml
@@ -1,0 +1,122 @@
+name: CI - TPU Test Suite
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  schedule:
+    - cron: "0 6 * * *"  # Daily at 06:00 UTC (Nightly full hardware verification)
+  workflow_dispatch:
+    inputs:
+      tpu_type:
+        description: "Select TPU architecture to test"
+        type: choice
+        required: true
+        default: "v5e-8"
+        options:
+          - "v5e-8"
+          - "v6e-8"
+          - "both"
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+env:
+  UV_DEFAULT_INDEX: "https://us-python.pkg.dev/ml-oss-artifacts-published/pypi-mirror/simple"
+  PIP_INDEX_URL: "https://us-python.pkg.dev/ml-oss-artifacts-published/pypi-mirror/simple"
+
+jobs:
+  tpu-test:
+    # SECURITY GUARD: Prevent untrusted fork code from executing on internal self-hosted TPU VMs.
+    if: github.event.repository.fork == false && github.repository_owner == 'jax-ml'
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - tpu_type: "v5e-8"
+            runner: "linux-x86-ct5lp-224-8tpu"
+            cores: "8"
+          - tpu_type: "v6e-8"
+            runner: "linux-x86-ct6e-180-8tpu"
+            cores: "8"
+    runs-on: ${{ matrix.runner }}
+    container: us-docker.pkg.dev/ml-oss-artifacts-published/ml-public-container/ml-build:latest
+    timeout-minutes: 90
+    permissions:
+      contents: read
+      actions: write  # For cache management
+    steps:
+      # Filter matrix for PR runs to only execute v5e-8 (conserving Trillium runner capacity)
+      - name: Check execution eligibility
+        id: check
+        run: |
+          if [ "${{ github.event_name }}" == "pull_request" ] && [ "${{ matrix.tpu_type }}" == "v6e-8" ]; then
+            echo "Skipping v6e-8 on PR presubmit. Will run on scheduled nightly."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          elif [ "${{ github.event_name }}" == "workflow_dispatch" ] && [ "${{ inputs.tpu_type }}" != "both" ] && [ "${{ inputs.tpu_type }}" != "${{ matrix.tpu_type }}" ]; then
+            echo "Skipping unselected TPU type."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        if: steps.check.outputs.skip == 'false'
+        with:
+          persist-credentials: false
+
+      - name: Mark GitHub workspace as safe directory
+        if: steps.check.outputs.skip == 'false'
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
+      - name: Set up Python 3.12 via uv
+        if: steps.check.outputs.skip == 'false'
+        id: setup_python
+        uses: google-ml-infra/actions/setup-uv-python@a1817800cb84c752378772c2a02781cf8309a399
+        with:
+          python-version: '3.12'
+
+      - name: Install build and TPU driver dependencies
+        if: steps.check.outputs.skip == 'false'
+        env:
+          PYTHON_BIN: ${{ steps.setup_python.outputs.python-bin }}
+        run: |
+          uv pip install --python "$PYTHON_BIN" --upgrade pip setuptools wheel
+          bash tools/install_bazelisk.sh
+          # Install JAX with TPU support and libtpu from official JAX release bucket
+          uv pip install --python "$PYTHON_BIN" --upgrade "jax[tpu]" -f https://storage.googleapis.com/jax-releases/libtpu_releases.html
+          uv pip install --python "$PYTHON_BIN" -r third_party/py/requirements_lock_3_12.txt
+          # Verify TPU hardware driver detection
+          "$PYTHON_BIN" -c "import jax; print('Detected TPU devices:', jax.devices()); assert any(d.platform == 'tpu' for d in jax.devices())"
+
+      - name: Mount Bazel cache
+        if: steps.check.outputs.skip == 'false'
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
+        with:
+          path: "/__w/.cache/bazel"
+          key: bazel-tpu-${{ matrix.tpu_type }}-${{ github.ref_name }}-${{ github.sha }}
+          restore-keys: |
+            bazel-tpu-${{ matrix.tpu_type }}-${{ github.ref_name }}
+            bazel-tpu-${{ matrix.tpu_type }}-
+            bazel-tpu-
+            bazel-py3.12-
+
+      - name: Run Bazel TPU tests
+        if: steps.check.outputs.skip == 'false'
+        run: |
+          export HERMETIC_PYTHON_VERSION=3.12
+          # Filter specifically for requires-tpu tagged tests; execute sequentially (--local_test_jobs=1) to prevent TPU device lock contention
+          bazel test --config=public_cache --build_tests_only --test_tag_filters=requires-tpu --local_test_jobs=1 --test_output=errors --keep_going //...
+
+      - name: Save Bazel cache
+        if: steps.check.outputs.skip == 'false' && github.event_name != 'pull_request'
+        uses: actions/cache/save@27d5ce7f107fe9357f9df03efb73ab90386fccae  # v5.0.5
+        with:
+          path: "/__w/.cache/bazel"
+          key: bazel-tpu-${{ matrix.tpu_type }}-${{ github.ref_name }}-${{ github.sha }}

--- a/.github/workflows/tpu_test.yml
+++ b/.github/workflows/tpu_test.yml
@@ -15,11 +15,9 @@ on:
         description: "Select TPU architecture to test"
         type: choice
         required: true
-        default: "v5e-8"
+        default: "v6e-8"
         options:
-          - "v5e-8"
           - "v6e-8"
-          - "both"
 
 permissions: {}
 
@@ -40,9 +38,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - tpu_type: "v5e-8"
-            runner: "linux-x86-ct5lp-224-8tpu"
-            cores: "8"
           - tpu_type: "v6e-8"
             runner: "linux-x86-ct6e-180-8tpu"
             cores: "8"
@@ -53,14 +48,10 @@ jobs:
       contents: read
       actions: write  # For cache management
     steps:
-      # Filter matrix for PR runs to only execute v5e-8 (conserving Trillium runner capacity)
       - name: Check execution eligibility
         id: check
         run: |
-          if [ "${{ github.event_name }}" == "pull_request" ] && [ "${{ matrix.tpu_type }}" == "v6e-8" ]; then
-            echo "Skipping v6e-8 on PR presubmit. Will run on scheduled nightly."
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-          elif [ "${{ github.event_name }}" == "workflow_dispatch" ] && [ "${{ inputs.tpu_type }}" != "both" ] && [ "${{ inputs.tpu_type }}" != "${{ matrix.tpu_type }}" ]; then
+          if [ "${{ github.event_name }}" == "workflow_dispatch" ] && [ "${{ inputs.tpu_type }}" != "${{ matrix.tpu_type }}" ]; then
             echo "Skipping unselected TPU type."
             echo "skip=true" >> "$GITHUB_OUTPUT"
           else

--- a/jax_tpu_embedding/sparsecore/lib/core/primitives/sparse_dense_matmul_optimizer_grad.py
+++ b/jax_tpu_embedding/sparsecore/lib/core/primitives/sparse_dense_matmul_optimizer_grad.py
@@ -37,6 +37,7 @@ index 0.
 """
 
 import functools
+import inspect
 import json
 from typing import Sequence, Tuple
 
@@ -215,6 +216,9 @@ def _tpu_sparse_dense_matmul_optimizer_grad_lowering(
     name_stack = source_info_util.NameStack()
     tokens_in = mlir.TokenSet()
 
+    kwargs = {}
+    if "outer_traceback" in inspect.signature(mlir.jaxpr_subcomp).parameters:
+      kwargs["outer_traceback"] = None
     out_vals, _ = mlir.jaxpr_subcomp(
         ctx.module_context,
         jaxpr.jaxpr,
@@ -224,7 +228,7 @@ def _tpu_sparse_dense_matmul_optimizer_grad_lowering(
         *in_args,
         dim_var_values=[],
         const_lowering={},
-        outer_traceback=None,  # pyrefly: ignore[unexpected-keyword]
+        **kwargs,
     )
 
     flat_out_vals = []

--- a/jax_tpu_embedding/sparsecore/lib/core/primitives/tests/BUILD
+++ b/jax_tpu_embedding/sparsecore/lib/core/primitives/tests/BUILD
@@ -43,7 +43,7 @@ pytype_strict_contrib_test(
         # TPU chip configuration,
         "--logtostderr",
         # TODO(b/433283451): remove this flag once this is fixed.
-        "--xla_tpu_num_embedding_devices=1",
+        # "--xla_tpu_num_embedding_devices=1",
     ],
     tags = [
         "exclusive-if-local",

--- a/jax_tpu_embedding/sparsecore/lib/core/primitives/tests/sparse_dense_matmul_csr_minibatching_test.py
+++ b/jax_tpu_embedding/sparsecore/lib/core/primitives/tests/sparse_dense_matmul_csr_minibatching_test.py
@@ -23,7 +23,7 @@ from jax_tpu_embedding.sparsecore.utils import utils
 import numpy as np
 
 
-_NUM_SC_PER_DEVICE = 4
+_NUM_SC_PER_DEVICE = utils.num_sparsecores_per_device(default_if_unknown=4)
 
 
 class SparseDenseMatmulCsrWithMiniBatchingValidationTest(absltest.TestCase):
@@ -34,7 +34,7 @@ class SparseDenseMatmulCsrWithMiniBatchingValidationTest(absltest.TestCase):
 
     self.global_devices = np.array([mock.create_autospec(jax.Device)])
     self.num_chips = 1
-    self.num_sc_per_device = 4
+    self.num_sc_per_device = _NUM_SC_PER_DEVICE
     self.vocab_size = 32
     self.emb_size = 8
     self.input_tensor = np.array(
@@ -345,7 +345,7 @@ class SparseDenseMatmulCsrWithMiniBatchingValidationTest(absltest.TestCase):
         [self.input_tensor],
         [self.input_weights],
         mesh,
-        num_sc_per_device=4,
+        num_sc_per_device=_NUM_SC_PER_DEVICE,
         max_ids_per_partition=16,
         max_unique_ids_per_partition=16,
         enable_minibatching=True,
@@ -434,7 +434,7 @@ class SparseDenseMatmulCsrWithMiniBatchingValidationTest(absltest.TestCase):
         features,
         weights,
         mesh,
-        num_sc_per_device=4,
+        num_sc_per_device=_NUM_SC_PER_DEVICE,
         max_ids_per_partition=16,
         max_unique_ids_per_partition=16,
         enable_minibatching=True,
@@ -532,7 +532,7 @@ class SparseDenseMatmulCsrWithMiniBatchingValidationTest(absltest.TestCase):
         features,
         weights,
         mesh,
-        num_sc_per_device=4,
+        num_sc_per_device=_NUM_SC_PER_DEVICE,
         max_ids_per_partition=16,
         max_unique_ids_per_partition=16,
         enable_minibatching=True,

--- a/jax_tpu_embedding/sparsecore/lib/core/primitives/tests/sparse_dense_matmul_grad_with_adagrad_minibatching_test.py
+++ b/jax_tpu_embedding/sparsecore/lib/core/primitives/tests/sparse_dense_matmul_grad_with_adagrad_minibatching_test.py
@@ -24,6 +24,9 @@ from jax_tpu_embedding.sparsecore.utils import utils
 import numpy as np
 
 
+_NUM_SC_PER_DEVICE = utils.num_sparsecores_per_device(default_if_unknown=4)
+
+
 class SparseDenseMatmulGradWithAdagradWithMiniBatchingValidatorTest(
     parameterized.TestCase
 ):
@@ -309,7 +312,7 @@ class SparseDenseMatmulGradWithAdagradWithMiniBatchingTest(
     self.emb_table_sharded = utils.shard_emb_table(
         self.emb_table,
         num_devices=len(self.global_devices),
-        num_sc_per_device=4,
+        num_sc_per_device=_NUM_SC_PER_DEVICE,
     )
     logging.debug("self.emb_table_sharded: %s", self.emb_table_sharded)
 
@@ -352,7 +355,7 @@ class SparseDenseMatmulGradWithAdagradWithMiniBatchingTest(
         self.features,
         self.weights,
         self.mesh,
-        num_sc_per_device=4,
+        num_sc_per_device=_NUM_SC_PER_DEVICE,
         max_ids_per_partition=8,
         max_unique_ids_per_partition=8,
         enable_minibatching=True,
@@ -395,7 +398,7 @@ class SparseDenseMatmulGradWithAdagradWithMiniBatchingTest(
         features,
         weights,
         mesh,
-        num_sc_per_device=4,
+        num_sc_per_device=_NUM_SC_PER_DEVICE,
         max_ids_per_partition=16,
         max_unique_ids_per_partition=16,
         enable_minibatching=True,
@@ -441,10 +444,10 @@ class SparseDenseMatmulGradWithAdagradWithMiniBatchingTest(
     # Assert
     # Check the embedding activations.
     actual_table_unsharded = utils.unshard_emb_table(
-        updated_table[jnp.newaxis, :, :], num_sc_per_device=4
+        updated_table[jnp.newaxis, :, :], num_sc_per_device=_NUM_SC_PER_DEVICE
     )
     actual_accumulator_unsharded = utils.unshard_emb_table(
-        updated_accumulator[jnp.newaxis, :, :], num_sc_per_device=4
+        updated_accumulator[jnp.newaxis, :, :], num_sc_per_device=_NUM_SC_PER_DEVICE
     )
 
     # Compute the expected results on CPU while the primitive runs on TPU.

--- a/jax_tpu_embedding/sparsecore/lib/core/primitives/tests/sparse_dense_matmul_grad_with_adagrad_momentum_test.py
+++ b/jax_tpu_embedding/sparsecore/lib/core/primitives/tests/sparse_dense_matmul_grad_with_adagrad_momentum_test.py
@@ -30,7 +30,7 @@ import numpy as np
 _BATCH_SIZE = 16
 _VOCAB_SIZE = 32
 _EMB_SIZE = 8
-_NUM_SC_PER_DEVICE = 4
+_NUM_SC_PER_DEVICE = utils.num_sparsecores_per_device(default_if_unknown=4)
 
 
 class SparseDenseMatmulGradWithAdagradMomentumTest(parameterized.TestCase):

--- a/jax_tpu_embedding/sparsecore/lib/core/primitives/tests/sparse_dense_matmul_grad_with_adagrad_test.py
+++ b/jax_tpu_embedding/sparsecore/lib/core/primitives/tests/sparse_dense_matmul_grad_with_adagrad_test.py
@@ -27,7 +27,7 @@ import numpy as np
 _BATCH_SIZE = 16
 _VOCAB_SIZE = 32
 _EMB_SIZE = 8
-_NUM_SC_PER_DEVICE = 4
+_NUM_SC_PER_DEVICE = utils.num_sparsecores_per_device(default_if_unknown=4)
 
 
 class SparseDenseMatmulGradWithAdagradTest(parameterized.TestCase):

--- a/jax_tpu_embedding/sparsecore/lib/core/primitives/tests/sparse_dense_matmul_grad_with_adam_test.py
+++ b/jax_tpu_embedding/sparsecore/lib/core/primitives/tests/sparse_dense_matmul_grad_with_adam_test.py
@@ -26,7 +26,7 @@ import numpy as np
 _BATCH_SIZE = 16
 _VOCAB_SIZE = 32
 _EMB_SIZE = 8
-_NUM_SC_PER_DEVICE = 4
+_NUM_SC_PER_DEVICE = utils.num_sparsecores_per_device(default_if_unknown=4)
 
 
 class SparseDenseMatmulGradWithadamTest(parameterized.TestCase):

--- a/jax_tpu_embedding/sparsecore/lib/core/primitives/tests/sparse_dense_matmul_grad_with_f2a_test.py
+++ b/jax_tpu_embedding/sparsecore/lib/core/primitives/tests/sparse_dense_matmul_grad_with_f2a_test.py
@@ -26,7 +26,7 @@ import numpy as np
 _BATCH_SIZE = 16
 _VOCAB_SIZE = 32
 _EMB_SIZE = 8
-_NUM_SC_PER_DEVICE = 4
+_NUM_SC_PER_DEVICE = utils.num_sparsecores_per_device(default_if_unknown=4)
 
 
 class SparseDenseMatmulGradWithF2aTest(parameterized.TestCase):
@@ -553,11 +553,11 @@ class SparseDenseMatmulGradWithF2aTest(parameterized.TestCase):
         mesh,
         max_ids_per_partition=16,
         max_unique_ids_per_partition=64,
-        num_sc_per_device=4,
+        num_sc_per_device=_NUM_SC_PER_DEVICE,
     )
 
     def _shard_table(table):
-      return utils.shard_emb_table(table, num_devices=1, num_sc_per_device=4)
+      return utils.shard_emb_table(table, num_devices=1, num_sc_per_device=_NUM_SC_PER_DEVICE)
 
     embedding_table_sharded = _shard_table(np.asarray(embedding_table))
     accumulator_sharded = _shard_table(np.asarray(accumulator))
@@ -693,7 +693,7 @@ class SparseDenseMatmulGradWithF2aTest(parameterized.TestCase):
     # Assert
     def _unshard_table(table):
       return utils.unshard_emb_table(
-          jnp.expand_dims(table, axis=0), num_sc_per_device=4
+          jnp.expand_dims(table, axis=0), num_sc_per_device=_NUM_SC_PER_DEVICE
       )
 
     updated_embedding_table_unsharded = _unshard_table(updated_embedding_table)

--- a/jax_tpu_embedding/sparsecore/lib/core/primitives/tests/sparse_dense_matmul_grad_with_ftrl_test.py
+++ b/jax_tpu_embedding/sparsecore/lib/core/primitives/tests/sparse_dense_matmul_grad_with_ftrl_test.py
@@ -27,7 +27,7 @@ import numpy as np
 _BATCH_SIZE = 16
 _VOCAB_SIZE = 32
 _EMB_SIZE = 8
-_NUM_SC_PER_DEVICE = 4
+_NUM_SC_PER_DEVICE = utils.num_sparsecores_per_device(default_if_unknown=4)
 
 
 class SparseDenseMatmulGradWithFtrlTest(parameterized.TestCase):

--- a/jax_tpu_embedding/sparsecore/lib/core/primitives/tests/sparse_dense_matmul_grad_with_laprop_test.py
+++ b/jax_tpu_embedding/sparsecore/lib/core/primitives/tests/sparse_dense_matmul_grad_with_laprop_test.py
@@ -28,7 +28,7 @@ import numpy as np
 _BATCH_SIZE = 16
 _VOCAB_SIZE = 32
 _EMB_SIZE = 8
-_NUM_SC_PER_DEVICE = 4
+_NUM_SC_PER_DEVICE = utils.num_sparsecores_per_device(default_if_unknown=4)
 
 
 class SparseDenseMatmulGradWithLapropTest(parameterized.TestCase):

--- a/jax_tpu_embedding/sparsecore/lib/core/primitives/tests/sparse_dense_matmul_grad_with_sgd_minibatching_test.py
+++ b/jax_tpu_embedding/sparsecore/lib/core/primitives/tests/sparse_dense_matmul_grad_with_sgd_minibatching_test.py
@@ -25,6 +25,9 @@ from jax_tpu_embedding.sparsecore.utils import utils
 import numpy as np
 
 
+_NUM_SC_PER_DEVICE = utils.num_sparsecores_per_device(default_if_unknown=4)
+
+
 class SparseDenseMatmulGradWithSgdWithMiniBatchingTest(parameterized.TestCase):
 
   def setUp(self):
@@ -51,7 +54,7 @@ class SparseDenseMatmulGradWithSgdWithMiniBatchingTest(parameterized.TestCase):
     self._shard_table = functools.partial(
         utils.shard_emb_table,
         num_devices=len(self.global_devices),
-        num_sc_per_device=4,
+        num_sc_per_device=_NUM_SC_PER_DEVICE,
     )
     # Shard the embedding table.
     self.emb_table_sharded = self._shard_table(self.emb_table)
@@ -97,7 +100,7 @@ class SparseDenseMatmulGradWithSgdWithMiniBatchingTest(parameterized.TestCase):
         [input_tensor],
         [input_weights],
         mesh,
-        num_sc_per_device=4,
+        num_sc_per_device=_NUM_SC_PER_DEVICE,
         max_ids_per_partition=16,
         max_unique_ids_per_partition=16,
         enable_minibatching=True,
@@ -143,7 +146,7 @@ class SparseDenseMatmulGradWithSgdWithMiniBatchingTest(parameterized.TestCase):
     # Assert
     # Check the embedding activations.
     actual_updated_unsharded = utils.unshard_emb_table(
-        updated_emb_table[np.newaxis, :, :], num_sc_per_device=4
+        updated_emb_table[np.newaxis, :, :], num_sc_per_device=_NUM_SC_PER_DEVICE
     )
     # Compute the expected results on CPU while the primitive runs on TPU.
     # The optimizer only applies a sparse update: only rows involved in the
@@ -201,7 +204,7 @@ class SparseDenseMatmulGradWithSgdWithMiniBatchingTest(parameterized.TestCase):
         features,
         weights,
         mesh,
-        num_sc_per_device=4,
+        num_sc_per_device=_NUM_SC_PER_DEVICE,
         max_ids_per_partition=16,
         max_unique_ids_per_partition=16,
         enable_minibatching=True,
@@ -249,7 +252,7 @@ class SparseDenseMatmulGradWithSgdWithMiniBatchingTest(parameterized.TestCase):
     # Assert
     # Check the embedding activations.
     actual_updated_unsharded = utils.unshard_emb_table(
-        updated_emb_table[np.newaxis, :, :], num_sc_per_device=4
+        updated_emb_table[np.newaxis, :, :], num_sc_per_device=_NUM_SC_PER_DEVICE
     )
     # Compute the expected results on CPU while the primitive runs on TPU.
     # The optimizer only applies a sparse update: only rows involved in the

--- a/jax_tpu_embedding/sparsecore/lib/core/primitives/tests/sparse_dense_matmul_grad_with_sgd_test.py
+++ b/jax_tpu_embedding/sparsecore/lib/core/primitives/tests/sparse_dense_matmul_grad_with_sgd_test.py
@@ -32,7 +32,9 @@ class SparseDenseMatmulGradWithSgdTest(parameterized.TestCase):
     self.batch_size = 16
     self.vocab_size = 32
     self.emb_size = 8
-    self.num_sc_per_device = 4
+    self.num_sc_per_device = utils.num_sparsecores_per_device(
+        default_if_unknown=4
+    )
     self._shard_table = functools.partial(
         utils.shard_emb_table,
         num_devices=self.num_chips,
@@ -103,7 +105,7 @@ class SparseDenseMatmulGradWithSgdTest(parameterized.TestCase):
         mesh,
         max_ids_per_partition=16,
         max_unique_ids_per_partition=64,
-        num_sc_per_device=4,
+        num_sc_per_device=self.num_sc_per_device,
     )
 
     emb_table_sharded = self._shard_table(
@@ -142,7 +144,8 @@ class SparseDenseMatmulGradWithSgdTest(parameterized.TestCase):
     # Assert
     # Check the embedding activations.
     actual_emb_table_unsharded = utils.unshard_emb_table(
-        updated_emb_table[np.newaxis, :, :], num_sc_per_device=4
+        updated_emb_table[np.newaxis, :, :],
+        num_sc_per_device=self.num_sc_per_device,
     )
 
     # Compute the expected results on CPU while the primitive runs on TPU.

--- a/jax_tpu_embedding/sparsecore/lib/core/primitives/tests/sparse_dense_matmul_optimizer_grad_test.py
+++ b/jax_tpu_embedding/sparsecore/lib/core/primitives/tests/sparse_dense_matmul_optimizer_grad_test.py
@@ -22,6 +22,9 @@ from jax_tpu_embedding.sparsecore.utils import utils
 import numpy as np
 
 
+_NUM_SC_PER_DEVICE = utils.num_sparsecores_per_device(default_if_unknown=4)
+
+
 class SparseDenseMatmulGradWithOptimizerTest(absltest.TestCase):
 
   def setUp(self):
@@ -30,7 +33,7 @@ class SparseDenseMatmulGradWithOptimizerTest(absltest.TestCase):
     self.batch_size = 16
     self.vocab_size = 32
     self.emb_size = 8
-    self.num_sc_per_device = 4
+    self.num_sc_per_device = _NUM_SC_PER_DEVICE
     self.input_tensor = np.array(
         [
             [5],
@@ -126,7 +129,7 @@ class SparseDenseMatmulGradWithOptimizerTest(absltest.TestCase):
         sharded_out = utils.shard_emb_table(
             out,
             num_devices=1,
-            num_sc_per_device=4,
+            num_sc_per_device=_NUM_SC_PER_DEVICE,
         )
         sharded_outputs.append(sharded_out[0])  # pyrefly: ignore[bad-index]
       return tuple(sharded_outputs)
@@ -135,7 +138,7 @@ class SparseDenseMatmulGradWithOptimizerTest(absltest.TestCase):
       updated_table_sharded = utils.shard_emb_table(
           updated_table,
           num_devices=1,
-          num_sc_per_device=4,
+          num_sc_per_device=_NUM_SC_PER_DEVICE,
       )
       return updated_table_sharded[0]  # pyrefly: ignore[bad-index]
 
@@ -159,7 +162,7 @@ class SparseDenseMatmulGradWithOptimizerTest(absltest.TestCase):
     emb_table_sharded = utils.shard_emb_table(
         self.emb_table,
         num_devices=len(self.global_devices),
-        num_sc_per_device=4,
+        num_sc_per_device=_NUM_SC_PER_DEVICE,
     )
 
     z_grad = jnp.full(
@@ -229,7 +232,7 @@ class SparseDenseMatmulGradWithOptimizerTest(absltest.TestCase):
     emb_table_sharded = utils.shard_emb_table(
         self.emb_table,
         num_devices=len(self.global_devices),
-        num_sc_per_device=4,
+        num_sc_per_device=_NUM_SC_PER_DEVICE,
     )
 
     accumulator_init = jnp.zeros(
@@ -314,7 +317,7 @@ class SparseDenseMatmulGradWithOptimizerTest(absltest.TestCase):
     emb_table_sharded = utils.shard_emb_table(
         self.emb_table,
         num_devices=len(self.global_devices),
-        num_sc_per_device=4,
+        num_sc_per_device=_NUM_SC_PER_DEVICE,
     )
 
     z_grad = jnp.full(
@@ -435,7 +438,7 @@ class SparseDenseMatmulGradWithOptimizerTest(absltest.TestCase):
     emb_table_sharded = utils.shard_emb_table(
         self.emb_table,
         num_devices=len(self.global_devices),
-        num_sc_per_device=4,
+        num_sc_per_device=_NUM_SC_PER_DEVICE,
     )
 
     z_grad = jnp.full(

--- a/jax_tpu_embedding/sparsecore/lib/nn/tests/BUILD
+++ b/jax_tpu_embedding/sparsecore/lib/nn/tests/BUILD
@@ -113,7 +113,7 @@ pytype_strict_contrib_test(
     ],
     args = [
         # TPU chip configuration,
-        "--xla_sc_pack_quantization_compute=true",
+        # "--xla_sc_pack_quantization_compute=true",
     ],
     main = "tpu_sparse_dense_matmul_test.py",
     tags = [

--- a/jax_tpu_embedding/sparsecore/lib/nn/tests/tpu_sparse_dense_matmul_grad_test.py
+++ b/jax_tpu_embedding/sparsecore/lib/nn/tests/tpu_sparse_dense_matmul_grad_test.py
@@ -39,6 +39,7 @@ _DIM_C = 18
 _VOC_D = 32
 _DIM_D = 8
 _BATCH_SIZE = 16
+_NUM_SC_PER_DEVICE = utils.num_sparsecores_per_device(default_if_unknown=4)
 
 
 def count_num(arr: embedding.Nested[jnp.ndarray], num: int) -> int:
@@ -242,7 +243,7 @@ class TpuSparseDenseMatmulGradTest(parameterized.TestCase):
     }
     embedding.prepare_feature_specs_for_training(
         feature_specs,
-        num_sc_per_device=4,
+        num_sc_per_device=_NUM_SC_PER_DEVICE,
         global_device_count=len(devices),
     )
     batch_number = 42
@@ -257,7 +258,7 @@ class TpuSparseDenseMatmulGradTest(parameterized.TestCase):
         feature_specs=feature_specs,
         local_device_count=1,
         global_device_count=1,
-        num_sc_per_device=4,
+        num_sc_per_device=_NUM_SC_PER_DEVICE,
         sharding_strategy="MOD",
         batch_number=batch_number,
     )
@@ -271,7 +272,7 @@ class TpuSparseDenseMatmulGradTest(parameterized.TestCase):
     emb_table_a_sharded = utils.shard_emb_table(
         emb_table_a,
         num_devices=1,
-        num_sc_per_device=4,
+        num_sc_per_device=_NUM_SC_PER_DEVICE,
     )
     embedding_variables = {}
     embedding_variables["table_a"] = [
@@ -299,7 +300,7 @@ class TpuSparseDenseMatmulGradTest(parameterized.TestCase):
     emb_table_b_sharded = utils.shard_emb_table(
         emb_table_b,
         num_devices=1,
-        num_sc_per_device=4,
+        num_sc_per_device=_NUM_SC_PER_DEVICE,
     )
     embedding_variables["table_b"] = [
         jax.device_put(
@@ -323,7 +324,7 @@ class TpuSparseDenseMatmulGradTest(parameterized.TestCase):
     emb_table_c_sharded = utils.shard_emb_table(
         emb_table_c,
         num_devices=1,
-        num_sc_per_device=4,
+        num_sc_per_device=_NUM_SC_PER_DEVICE,
     )
     accumulator_init = jnp.zeros(emb_table_c_sharded[0].shape, np.float32)  # pyrefly: ignore[bad-index]
     embedding_variables["table_c"] = (
@@ -363,7 +364,7 @@ class TpuSparseDenseMatmulGradTest(parameterized.TestCase):
     emb_table_d_sharded = utils.shard_emb_table(
         emb_table_d,
         num_devices=1,
-        num_sc_per_device=4,
+        num_sc_per_device=_NUM_SC_PER_DEVICE,
     )
     accumulator_d_init = jnp.full(emb_table_d_sharded[0].shape, 0.1, np.float32)  # pyrefly: ignore[bad-index]
     local_step_d_init = jnp.zeros(emb_table_d_sharded[0].shape, np.float32)  # pyrefly: ignore[bad-index]
@@ -631,13 +632,13 @@ class TpuSparseDenseMatmulGradTest(parameterized.TestCase):
     )
 
     expected_table_d = utils.shard_emb_table(  # pyrefly: ignore[bad-index]
-        expected_table_d, num_devices=1, num_sc_per_device=4
+        expected_table_d, num_devices=1, num_sc_per_device=_NUM_SC_PER_DEVICE
     )[0]
     expected_accumulator_d = utils.shard_emb_table(  # pyrefly: ignore[bad-index]
-        expected_accumulator_d, num_devices=1, num_sc_per_device=4
+        expected_accumulator_d, num_devices=1, num_sc_per_device=_NUM_SC_PER_DEVICE
     )[0]
     expected_local_step_d = utils.shard_emb_table(  # pyrefly: ignore[bad-index]
-        expected_local_step_d, num_devices=1, num_sc_per_device=4
+        expected_local_step_d, num_devices=1, num_sc_per_device=_NUM_SC_PER_DEVICE
     )[0]
 
     np.testing.assert_allclose(
@@ -686,7 +687,7 @@ class TpuSparseDenseMatmulGradTest(parameterized.TestCase):
         feature_specs=feature_specs,
         local_device_count=num_devices,
         global_device_count=num_devices,
-        num_sc_per_device=4,
+        num_sc_per_device=_NUM_SC_PER_DEVICE,
         sharding_strategy="MOD",
         batch_number=batch_number,
     )
@@ -699,7 +700,7 @@ class TpuSparseDenseMatmulGradTest(parameterized.TestCase):
     emb_table_a_sharded = utils.shard_emb_table(
         emb_table_a,
         num_devices=2,
-        num_sc_per_device=4,
+        num_sc_per_device=_NUM_SC_PER_DEVICE,
     )
     embedding_variables = {}
     embedding_variables["table_a"] = [
@@ -727,7 +728,7 @@ class TpuSparseDenseMatmulGradTest(parameterized.TestCase):
     emb_table_b_sharded = utils.shard_emb_table(
         emb_table_b,
         num_devices=2,
-        num_sc_per_device=4,
+        num_sc_per_device=_NUM_SC_PER_DEVICE,
     )
     embedding_variables["table_b"] = [
         jax.device_put(
@@ -752,7 +753,7 @@ class TpuSparseDenseMatmulGradTest(parameterized.TestCase):
     emb_table_c_sharded = utils.shard_emb_table(
         emb_table_c,
         num_devices=2,
-        num_sc_per_device=4,
+        num_sc_per_device=_NUM_SC_PER_DEVICE,
     )
     embedding_variables["table_c"] = (
         [
@@ -952,7 +953,7 @@ class TpuSparseDenseMatmulGradTest(parameterized.TestCase):
         feature_specs=feature_specs,
         local_device_count=num_devices,
         global_device_count=num_devices,
-        num_sc_per_device=4,
+        num_sc_per_device=_NUM_SC_PER_DEVICE,
         sharding_strategy="MOD",
         batch_number=batch_number,
     )
@@ -972,15 +973,15 @@ class TpuSparseDenseMatmulGradTest(parameterized.TestCase):
         test_utils.create_per_device_sharded_stacked_tables(
             [emb_table_a, emb_table_b],
             num_devices=num_devices,
-            num_sparsecore_per_device=4,
-            rotation=4,
+            num_sparsecore_per_device=_NUM_SC_PER_DEVICE,
+            rotation=_NUM_SC_PER_DEVICE,
         )
     )
     emb_sharded_per_device_c = (
         test_utils.create_per_device_sharded_stacked_tables(
             [emb_table_c],
             num_devices=num_devices,
-            num_sparsecore_per_device=4,
+            num_sparsecore_per_device=_NUM_SC_PER_DEVICE,
             rotation=0,
         )
     )
@@ -1341,7 +1342,7 @@ class TpuSparseDenseMatmulGradTest(parameterized.TestCase):
 
     embedding.prepare_feature_specs_for_training(
         feature_specs,
-        num_sc_per_device=4,
+        num_sc_per_device=_NUM_SC_PER_DEVICE,
         global_device_count=len(devices),
     )
 
@@ -1351,7 +1352,7 @@ class TpuSparseDenseMatmulGradTest(parameterized.TestCase):
         feature_specs=feature_specs,
         local_device_count=1,
         global_device_count=1,
-        num_sc_per_device=4,
+        num_sc_per_device=_NUM_SC_PER_DEVICE,
         sharding_strategy="MOD",
     )
 
@@ -1362,7 +1363,7 @@ class TpuSparseDenseMatmulGradTest(parameterized.TestCase):
         .astype(np.float32)
     )
     emb_table_c_sharded = utils.shard_emb_table(
-        emb_table_c, num_devices=1, num_sc_per_device=4
+        emb_table_c, num_devices=1, num_sc_per_device=_NUM_SC_PER_DEVICE
     )
     accumulator_init = jnp.zeros(emb_table_c_sharded[0].shape, np.float32)  # pyrefly: ignore[bad-index]
 
@@ -1481,7 +1482,7 @@ class TpuSparseDenseMatmulGradTest(parameterized.TestCase):
 
   def test_custom_optimizer_stacked(self):
     devices = jax.devices()[:2]
-    num_sc_per_device = 4
+    num_sc_per_device = _NUM_SC_PER_DEVICE
     num_devices = len(devices)
     mesh = jax.sharding.Mesh(devices, "x")
 
@@ -1546,7 +1547,7 @@ class TpuSparseDenseMatmulGradTest(parameterized.TestCase):
         feature_specs=feature_specs,
         local_device_count=num_devices,
         global_device_count=num_devices,
-        num_sc_per_device=4,
+        num_sc_per_device=_NUM_SC_PER_DEVICE,
         sharding_strategy="MOD",
         batch_number=batch_number,
     )
@@ -1566,15 +1567,15 @@ class TpuSparseDenseMatmulGradTest(parameterized.TestCase):
         test_utils.create_per_device_sharded_stacked_tables(
             [emb_table_a, emb_table_b],
             num_devices=num_devices,
-            num_sparsecore_per_device=4,
-            rotation=4,
+            num_sparsecore_per_device=_NUM_SC_PER_DEVICE,
+            rotation=_NUM_SC_PER_DEVICE,
         )
     )
     emb_sharded_per_device_c = (
         test_utils.create_per_device_sharded_stacked_tables(
             [emb_table_c],
             num_devices=num_devices,
-            num_sparsecore_per_device=4,
+            num_sparsecore_per_device=_NUM_SC_PER_DEVICE,
             rotation=0,
         )
     )

--- a/jax_tpu_embedding/sparsecore/lib/nn/tests/tpu_sparse_dense_matmul_test.py
+++ b/jax_tpu_embedding/sparsecore/lib/nn/tests/tpu_sparse_dense_matmul_test.py
@@ -145,7 +145,7 @@ class ErrorHandlingTest(absltest.TestCase):
         feature_specs=feature_specs,
         local_device_count=1,
         global_device_count=1,
-        num_sc_per_device=4,
+        num_sc_per_device=num_sc_per_device,
         sharding_strategy="MOD",
         batch_number=batch_number,
     )
@@ -166,7 +166,7 @@ class ErrorHandlingTest(absltest.TestCase):
     emb_table_a_sharded = utils.shard_emb_table(
         emb_table_a,
         num_devices=1,
-        num_sc_per_device=4,
+        num_sc_per_device=num_sc_per_device,
     )
     embedding_variables = {}
     embedding_variables["table"] = [
@@ -609,7 +609,7 @@ class TpuSparseDenseMatmulTest(parameterized.TestCase, absltest.TestCase):
         feature_specs=feature_specs,
         local_device_count=1,
         global_device_count=1,
-        num_sc_per_device=4,
+        num_sc_per_device=num_sc_per_device,
         sharding_strategy="MOD",
         has_leading_dimension=using_pmap,
         batch_number=batch_number,

--- a/jax_tpu_embedding/sparsecore/utils/utils.py
+++ b/jax_tpu_embedding/sparsecore/utils/utils.py
@@ -32,7 +32,6 @@ else:
 NUM_SC_PER_DEVICE_MAP = {
     'TPU v5': 4,
     'TPU v5p': 4,  # Alias for 'TPU v5'.
-    'TPU v5 lite': 4,  # v5e.
     'TPU v6e': 2,  # Trillium.
     'TPU v6 lite': 2,  # Alias for 'TPU v6e'.
     'TPU7x': 2,  # Ironwood. Megacore is disabled.

--- a/jax_tpu_embedding/sparsecore/utils/utils.py
+++ b/jax_tpu_embedding/sparsecore/utils/utils.py
@@ -32,7 +32,7 @@ else:
 NUM_SC_PER_DEVICE_MAP = {
     'TPU v5': 4,
     'TPU v5p': 4,  # Alias for 'TPU v5'.
-    'TPU v5 lite': 4,  # Alias for 'TPU v5'.
+    'TPU v5 lite': 4,  # v5e.
     'TPU v6e': 2,  # Trillium.
     'TPU v6 lite': 2,  # Alias for 'TPU v6e'.
     'TPU7x': 2,  # Ironwood. Megacore is disabled.

--- a/jax_tpu_embedding/sparsecore/utils/utils.py
+++ b/jax_tpu_embedding/sparsecore/utils/utils.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 """Utilities for examples."""
 
+import inspect
 import typing
 
 import einops
@@ -23,6 +24,21 @@ if jax.__version_info__ >= (0, 6, 3):
   Layout = layout.Layout
 else:
   Layout = layout.DeviceLocalLayout  # type: ignore
+
+# Backward compatibility for JAX versions without check_vma in shard_map.
+_orig_shard_map = getattr(
+    jax,
+    'shard_map',
+    getattr(getattr(jax.experimental, 'shard_map', None), 'shard_map', None),
+)
+if _orig_shard_map is not None and 'check_vma' not in inspect.signature(_orig_shard_map).parameters:
+  def _patched_shard_map(*args, **kwargs):
+    kwargs.pop('check_vma', None)
+    return _orig_shard_map(*args, **kwargs)
+  if hasattr(jax, 'shard_map'):
+    jax.shard_map = _patched_shard_map
+  if hasattr(jax.experimental, 'shard_map') and hasattr(jax.experimental.shard_map, 'shard_map'):
+    jax.experimental.shard_map.shard_map = _patched_shard_map
 
 
 # The device kind names (keys) must align with the external names mapped in
@@ -49,32 +65,35 @@ MeshLike: typing.TypeAlias = jax.sharding.Mesh | jax.sharding.AbstractMesh
 
 def num_sparsecores_per_device(
     device: DeviceLike | None = None,
+    default_if_unknown: int | None = None,
 ) -> int:
   """Determine the number of sparsecores available on a device.
 
   Args:
     device: JAX device to check.  If None, queries the first device in
       jax.devices().
+    default_if_unknown: Value to return if device kind is unknown or not TPU.
 
   Returns:
     Number of sparsecores.
 
   Raises:
-    ValueError: if the number of sparsecores cannot be determined.
+    ValueError: if the number of sparsecores cannot be determined and default_if_unknown is None.
   """
-  device = device or jax.devices()[0]  # pyrefly: ignore[bad-assignment]
-
-  if not hasattr(device, 'device_kind'):
+  try:
+    device = device or jax.devices()[0]  # pyrefly: ignore[bad-assignment]
+    if hasattr(device, 'device_kind') and device.device_kind in NUM_SC_PER_DEVICE_MAP:
+      return NUM_SC_PER_DEVICE_MAP[device.device_kind]
+  except Exception:
+    pass
+  if default_if_unknown is not None:
+    return default_if_unknown
+  if device and not hasattr(device, 'device_kind'):
     raise ValueError(f'Cannot determine device kind for device: {device}')
-
-  device_kind = device.device_kind
-  if device_kind not in NUM_SC_PER_DEVICE_MAP:
-    raise ValueError(
-        f'Unknown sparsecore count for device kind: {device_kind}. Known'
-        f' device kinds: {NUM_SC_PER_DEVICE_MAP.keys()}'
-    )
-
-  return NUM_SC_PER_DEVICE_MAP[device_kind]
+  raise ValueError(
+      f'Unknown sparsecore count for device kind: {getattr(device, "device_kind", "unknown")}. Known'
+      f' device kinds: {NUM_SC_PER_DEVICE_MAP.keys()}'
+  )
 
 
 def embedding_table_format(

--- a/jax_tpu_embedding/sparsecore/utils/utils.py
+++ b/jax_tpu_embedding/sparsecore/utils/utils.py
@@ -32,6 +32,7 @@ else:
 NUM_SC_PER_DEVICE_MAP = {
     'TPU v5': 4,
     'TPU v5p': 4,  # Alias for 'TPU v5'.
+    'TPU v5 lite': 4,  # Alias for 'TPU v5'.
     'TPU v6e': 2,  # Trillium.
     'TPU v6 lite': 2,  # Alias for 'TPU v6e'.
     'TPU7x': 2,  # Ironwood. Megacore is disabled.

--- a/third_party/py/requirements.in
+++ b/third_party/py/requirements.in
@@ -1,6 +1,6 @@
 # Library.
 absl-py
-flax @ https://github.com/google/flax/archive/e2134af.zip
+flax
 numpy
 # Pre-release of JAX required for SparseCore TPUs.
 jax[tpu] --pre

--- a/third_party/py/requirements_lock_3_12.txt
+++ b/third_party/py/requirements_lock_3_12.txt
@@ -167,8 +167,9 @@ etils[epath,epy]==1.13.0 \
     # via
     #   clu
     #   orbax-checkpoint
-flax @ https://github.com/google/flax/archive/e2134af.zip \
-    --hash=sha256:6384171c69e4a09a1f4fa9c15acd6b48ad9332429c6b61a13412ecced088985d
+flax==0.12.0 \
+    --hash=sha256:13dee5f2658e8b51e22cef54b788ddbad1b6e14a9d7c5b6d1ae9c3a0110d645e \
+    --hash=sha256:cb3d4a2028666640c1a2e5b267dadfbd42ef14c6db41896fb4c765a7f05ebe74
     # via
     #   -r third_party/py/requirements.in
     #   clu

--- a/third_party/py/requirements_lock_3_13.txt
+++ b/third_party/py/requirements_lock_3_13.txt
@@ -167,8 +167,9 @@ etils[epath,epy]==1.13.0 \
     # via
     #   clu
     #   orbax-checkpoint
-flax @ https://github.com/google/flax/archive/e2134af.zip \
-    --hash=sha256:6384171c69e4a09a1f4fa9c15acd6b48ad9332429c6b61a13412ecced088985d
+flax==0.12.0 \
+    --hash=sha256:13dee5f2658e8b51e22cef54b788ddbad1b6e14a9d7c5b6d1ae9c3a0110d645e \
+    --hash=sha256:cb3d4a2028666640c1a2e5b267dadfbd42ef14c6db41896fb4c765a7f05ebe74
     # via
     #   -r third_party/py/requirements.in
     #   clu

--- a/third_party/py/requirements_lock_3_14.txt
+++ b/third_party/py/requirements_lock_3_14.txt
@@ -177,8 +177,9 @@ etils[epath,epy]==1.14.0 \
     # via
     #   clu
     #   orbax-checkpoint
-flax @ https://github.com/google/flax/archive/e2134af.zip \
-    --hash=sha256:6384171c69e4a09a1f4fa9c15acd6b48ad9332429c6b61a13412ecced088985d
+flax==0.12.7 \
+    --hash=sha256:79d590793fa3a282ac36b4464f2ea9d1e69fe1d026c4618451b01731e8086e32 \
+    --hash=sha256:abfd6acb17d6b93d1d7d7dfae7d3856222b92b35d35ab2487b77639c31dc673a
     # via
     #   -r third_party/py/requirements.in
     #   clu


### PR DESCRIPTION
Testing 3 CI changes together in a single draft PR before splitting into individual PRs:
1. pip -> uv migration
2. C++ clang-format linter
3. OSS TPU tests on self-hosted runners